### PR TITLE
NullReferenceException fix for SimLoopListener

### DIFF
--- a/SimFell/Sim/SimLoopListener.cs
+++ b/SimFell/Sim/SimLoopListener.cs
@@ -17,11 +17,13 @@ public abstract class SimLoopListener
 
     public void Stop()
     {
-        SimLoop.OnUpdate -= Update;
+        if (SimLoop != null)
+            SimLoop.OnUpdate -= Update;
     }
 
     ~SimLoopListener()
     {
-        SimLoop.OnUpdate -= Update;
+        if (SimLoop != null)
+            SimLoop.OnUpdate -= Update;
     }
 }


### PR DESCRIPTION
Bandaid solution for NullReferenceException caused by running multiplee "Rime-NoStats-2K-Average" sims

Resolves #1